### PR TITLE
Bugfix: Download button

### DIFF
--- a/module.js
+++ b/module.js
@@ -13,7 +13,7 @@ M.filter_jwplayer.addButton = function(Y, playerid, img, tttext) {
         //This portion designates the functionality of the button itself
         function() {
             //With the below code, we're grabbing the file that's currently playing
-            window.location.href = jwplayer().getPlaylistItem()['file'] + '?forcedownload=true';
+            window.location.href = jwplayer(playerid).getPlaylistItem()['file'] + '?forcedownload=true';
         },
         //And finally, here we set the unique ID of the button itself.
         "download"


### PR DESCRIPTION
Download buttons of any video on a page with multiple videos embedded just triggers the file download of the first embedded video.
