### PR TITLE
Add custom buttons support as $option param

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -116,6 +116,18 @@ class filter_jwplayer_media extends core_media_player {
      * @param int $width Optional width; 0 to use default
      * @param int $height Optional height; 0 to use default
      * @param array $options Options array
+     *                       buttons
+     *                           use 'buttons' key with an array of arrays with id, img, text, callback indexes
+     *                           id: unique id across all buttons assigned to this player
+     *                           img: an icon used for the button
+     *                           text: a label displayed while mouse over the button
+     *                           callback: a JavaScript function name used as callback, playerid provided as first parameter
+     *                           Example: $options['buttons'] = array(array(
+     *                               'id'=>'uniqueid',
+     *                               'img'=>http://path/to/img.png,
+     *                               'text'=>'label',
+     *                               'callback'=>'M.plugin.callback'))
+     *                           for more details see http://support.jwplayer.com/customer/portal/articles/1413089-javascript-api-reference#controls
      * @return string HTML code for embed
      */
     public function embed($urls, $name, $width, $height, $options) {
@@ -172,18 +184,26 @@ class filter_jwplayer_media extends core_media_player {
                 $playersetupdata['skin'] = $skin;
             }
 
-            $downloadbtn = null;
+            $buttons = array();
+
             if (get_config('filter_jwplayer', 'downloadbutton')) {
                 $downloadbtn = array(
                     'img' => $CFG->wwwroot.'/filter/jwplayer/img/download.png',
-                    'tttext' => get_string('videodownloadbtntttext', 'filter_jwplayer')
+                    'text' => get_string('videodownloadbtntttext', 'filter_jwplayer'),
+                    'callback' => 'M.filter_jwplayer.download',
+                    'id' => 'download'
                 );
+                $buttons[] = $downloadbtn;
+            }
+
+            if (isset($options['buttons']) && is_array($options['buttons'])) {
+                $buttons = array_merge($buttons, $options['buttons']);
             }
 
             $playersetup = array(
                 'playerid' => $playerid,
                 'setupdata' => $playersetupdata,
-                'downloadbtn' => $downloadbtn,
+                'buttons' => $buttons,
             );
 
             // Set up the player.

--- a/module.js
+++ b/module.js
@@ -3,19 +3,9 @@ M.filter_jwplayer = {};
 M.filter_jwplayer.init = function(Y, playerid, setupdata, buttons) {
     jwplayer(playerid).setup(setupdata);
 
-    var executenamespacedFunction = function(namespacedFunctionName, args) {
-        var namespaces = namespacedFunctionName.split(".");
-        var fn = namespaces.pop();
-        var context = window;
-        for (var i = 0; i < namespaces.length; i++) {
-            context = context[namespaces[i]];
-        }
-        context[fn].apply(context, args);
-    };
-
     function btncallback(i) {
         return function() {
-            executenamespacedFunction(buttons[i].callback, [playerid]);
+            M.filter_jwplayer.execute_namespaced_function(buttons[i].callback, [playerid]);
         };
     }
 
@@ -26,4 +16,14 @@ M.filter_jwplayer.init = function(Y, playerid, setupdata, buttons) {
 
 M.filter_jwplayer.download = function(playerid) {
     window.location.href = jwplayer(playerid).getPlaylistItem().file + '?forcedownload=true';
+};
+
+M.filter_jwplayer.execute_namespaced_function = function(namespacedfunctionname, args) {
+    var namespaces = namespacedfunctionname.split(".");
+    var fn = namespaces.pop();
+    var context = window;
+    for (var i = 0; i < namespaces.length; i++) {
+        context = context[namespaces[i]];
+    }
+    context[fn].apply(context, args);
 };

--- a/module.js
+++ b/module.js
@@ -1,12 +1,29 @@
 M.filter_jwplayer = {};
 
-M.filter_jwplayer.init = function(Y, playerid, setupdata, downloadbtn) {
+M.filter_jwplayer.init = function(Y, playerid, setupdata, buttons) {
     jwplayer(playerid).setup(setupdata);
 
-    if (downloadbtn != undefined) {
-        jwplayer(playerid).addButton(downloadbtn.img, downloadbtn.tttext, function() {
-                // Grab the file that's currently playing.
-                window.location.href = jwplayer(playerid).getPlaylistItem().file + '?forcedownload=true';
-            }, "download");
+    var executenamespacedFunction = function(namespacedFunctionName, args) {
+        var namespaces = namespacedFunctionName.split(".");
+        var fn = namespaces.pop();
+        var context = window;
+        for (var i = 0; i < namespaces.length; i++) {
+            context = context[namespaces[i]];
+        }
+        context[fn].apply(context, args);
+    };
+
+    function btncallback(i) {
+        return function() {
+            executenamespacedFunction(buttons[i].callback, [playerid]);
+        };
     }
+
+    for (var i = 0; i < buttons.length; i++) {
+        jwplayer(playerid).addButton(buttons[i].img, buttons[i].text, btncallback(i), buttons[i].id);
+    }
+};
+
+M.filter_jwplayer.download = function(playerid) {
+    window.location.href = jwplayer(playerid).getPlaylistItem().file + '?forcedownload=true';
 };


### PR DESCRIPTION
Provide an options array entry with "buttons" key and an array of "button arrays" with id, img, text, callback indexes to add custom buttons to the player.
Adapted download button init to this new flexible buttons feature.

Example:

```
$options['buttons'] = array(array(
    'id'=>'uniqueid',
    'img'=>'http://path/to/img.png',
    'text'=>'label',
    'callback'=>'M.plugin.callback'));
```
