### PR TITLE
chapters/thumbnails support added to subtitle feature

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -161,9 +161,15 @@ class filter_jwplayer_media extends core_media_player {
             if (isset($options['subtitles'])) {
                 $tracks = array();
                 foreach ($options['subtitles'] as $label => $subtitlefileurl) {
-                    $tracks[] = array(
-                        'file' => $subtitlefileurl->out(),
-                        'label' => $label);
+                    if ($label == 'chapters' || $label == 'thumbnails') {
+                        $tracks[] = array(
+                            'file' => $subtitlefileurl->out(),
+                            'kind' => $label);
+                    } else {
+                        $tracks[] = array(
+                            'file' => $subtitlefileurl->out(),
+                            'label' => $label);
+                    }
                 }
                 $playlistitem['tracks'] = $tracks;
             }

--- a/lib.php
+++ b/lib.php
@@ -119,7 +119,14 @@ class filter_jwplayer_media extends core_media_player {
      *                       subtitles
      *                           use 'subtitles' key with an array of subtitle track files
      *                           in vtt or srt format indexed by label name.
-     *                           Example: $options['subtitles']['English'] = http://example.com/english.vtt
+     *                           use 'chapters' or 'thumbnail' index for adding chapters/thumbnails
+     *                           to the video. see:
+     *                               * http://support.jwplayer.com/customer/portal/articles/1407438-adding-closed-captions
+     *                               * http://support.jwplayer.com/customer/portal/articles/1407454-adding-chapter-markers
+     *                               * http://support.jwplayer.com/customer/portal/articles/1407439-adding-preview-thumbnails
+     *                           Examples:
+     *                               $options['subtitles']['English'] = http://example.com/english.vtt
+     *                               $options['subtitles']['chapters'] = http://example.com/chapters.vtt
      * @return string HTML code for embed
      */
     public function embed($urls, $name, $width, $height, $options) {

--- a/lib.php
+++ b/lib.php
@@ -117,7 +117,7 @@ class filter_jwplayer_media extends core_media_player {
      * @param int $height Optional height; 0 to use default
      * @param array $options Options array
      *                       subtitles
-     *                           use 'subtitles' key with an array of subtitle track files
+     *                           use 'subtitles' key with an array of moodle_url to subtitle track files
      *                           in vtt or srt format indexed by label name.
      *                           use 'chapters' or 'thumbnail' index for adding chapters/thumbnails
      *                           to the video. see:
@@ -125,8 +125,8 @@ class filter_jwplayer_media extends core_media_player {
      *                               * http://support.jwplayer.com/customer/portal/articles/1407454-adding-chapter-markers
      *                               * http://support.jwplayer.com/customer/portal/articles/1407439-adding-preview-thumbnails
      *                           Examples:
-     *                               $options['subtitles']['English'] = http://example.com/english.vtt
-     *                               $options['subtitles']['chapters'] = http://example.com/chapters.vtt
+     *                               $options['subtitles']['English'] = new moodle_url('english.vtt')
+     *                               $options['subtitles']['chapters'] = new moodle_url('chapters.vtt')
      * @return string HTML code for embed
      */
     public function embed($urls, $name, $width, $height, $options) {


### PR DESCRIPTION
Added support for chapters and thumbnail tracks within the subtitle feature.

jwplayer chapters and thumbnails feature:
- http://support.jwplayer.com/customer/portal/articles/1407454-adding-chapter-markers
- http://support.jwplayer.com/customer/portal/articles/1407439-adding-preview-thumbnails

I will rebase the commits if everything else is ready to merge.
