### PR TITLE
filter_jwplayer:  Add support for subtitles and poster images in # separated url

### DIFF
--- a/filter.php
+++ b/filter.php
@@ -114,7 +114,8 @@ class filter_jwplayer extends moodle_text_filter {
 
         // Split provided URL into alternatives.
         $urls = filter_jwplayer_split_alternatives($matches[1], $width, $height);
-        $result = $this->renderer->embed_alternatives($urls, $name, $width, $height, $options);
+        $options = array_merge($url['options'],$options);
+        $result = $this->renderer->embed_alternatives($urls['urls'], $name, $width, $height, $options);
 
         // If something was embedded, return it, otherwise return original.
         if ($result !== '') {

--- a/lib.php
+++ b/lib.php
@@ -78,6 +78,9 @@ function filter_jwplayer_split_alternatives($combinedurl, &$width, &$height) {
     $width = 0;
     $height = 0;
     $returnurls = array();
+    $returnoptions = array();
+    $posterextensions = array('jpeg', 'jpg', 'gif', 'png');
+    $subtitleextensions = array('vtt');
 
     foreach ($urls as $url) {
         $matches = null;
@@ -112,10 +115,28 @@ function filter_jwplayer_split_alternatives($combinedurl, &$width, &$height) {
         }
 
         // Turn it into moodle_url object.
-        $returnurls[] = new moodle_url($url);
+        $returnurl = new moodle_url($url);
+
+        // Check if its an image or subtitles
+        if (in_array($ext = core_media::get_extension($returnurl), $posterextensions)) {
+            $returnoptions['image'] = $returnurl;
+        }
+        if (in_array($ext,$subtitleextensions)) {
+            // Get subtitle label from filename with extension removed
+            $subtitlelabel = core_media::get_filename($returnurl);
+            $subtitlelabel = preg_replace('~\.[^.]*$~', '', $subtitlelabel);
+            $returnoptions['subtitles'][$subtitlelabel] = $returnurl;
+        }
+
+        $returnurls[] = $returnurl;
     }
 
-    return $returnurls;
+    $returndata = array (
+        'urls' => $returnurls,
+        'options' => $returnoptions
+    );
+	
+    return $returndata;
 }
 
 function filter_jwplayer_pluginfile($course, $cm, $context, $filearea, $args, $forcedownload, array $options = array()) {


### PR DESCRIPTION
Add option to include poster images and subtitles in amongst the # separated urls.
