### PR TITLE
filter_jwplayer:  Change div tags to span and update css to display inline (bug #3)

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -269,8 +269,8 @@ class filter_jwplayer_media extends core_media_player {
             $this->setup();
 
             $PAGE->requires->js_init_call('M.filter_jwplayer.init', $playersetup, true, $jsmodule);
-            $playerdiv = html_writer::tag('div', $this->get_name('', $urls), array('id' => $playerid));
-            $output .= html_writer::tag('div', $playerdiv, array('class' => 'filter_jwplayer_media'));
+            $playerdiv = html_writer::tag('span', $this->get_name('', $urls), array('id' => $playerid));
+            $output .= html_writer::tag('span', $playerdiv, array('class' => 'filter_jwplayer_media'));
         }
 
         return $output;

--- a/styles.css
+++ b/styles.css
@@ -2,3 +2,4 @@
  * Filter JWPlayer
  */
 .filter_jwplayer_media {display:block;margin-top:5px;margin-bottom:5px;text-align: center;}
+.filter_jwplayer_media .jwplayer{display:inline-block;}


### PR DESCRIPTION
I've switch the inserted div tags to span, which is more consistent with the core media filters and stops the issue of the surrounding tags being closed.

Added extra css to override the css added by the player, so it displays inline within our block.

This makes the player always centered (due to the existing text-align statement in the filter css) rather than left-aligned, but at least that's consistent with the core players.