### PR TITLE
Pass style options from a tag to player span tag (bug #3)

### DIFF
--- a/filter.php
+++ b/filter.php
@@ -95,15 +95,21 @@ class filter_jwplayer extends moodle_text_filter {
             return $matches[0];
         }
 
+        $options = array();
+		
         // Get name.
         $name = trim($matches[2]);
         if (empty($name) or strpos($name, 'http') === 0) {
             $name = ''; // Use default name.
         }
 
+        // Get <a> tag attributes
+        $atag = new SimpleXMLElement($matches[0]);
+        $options['htmlattributes'] = $atag->attributes();
+
         // Split provided URL into alternatives.
         $urls = filter_jwplayer_split_alternatives($matches[1], $width, $height);
-        $result = $this->renderer->embed_alternatives($urls, $name, $width, $height);
+        $result = $this->renderer->embed_alternatives($urls, $name, $width, $height, $options);
 
         // If something was embedded, return it, otherwise return original.
         if ($result !== '') {

--- a/lib.php
+++ b/lib.php
@@ -276,11 +276,20 @@ class filter_jwplayer_media extends core_media_player {
             );
 
             $this->setup();
+			
+            // Set attrigbutes for player span tag
+            $newattributes = array(
+                'class' => 'filter_jwplayer_media'
+            );
+
+            if(isset($options['htmlattributes']['style'])){
+                $newattributes['style'] = $options['htmlattributes']['style'];
+            }
 
             $PAGE->requires->js_init_call('M.filter_jwplayer.init', $playersetup, true, $jsmodule);
             $playerdiv = html_writer::tag('span', $this->get_name('', $urls), array('id' => $playerid));
             $outerspan = html_writer::tag('span', $playerdiv, array('class' => 'filter_jwplayer_playerblock'));
-            $output .= html_writer::tag('span', $outerspan, array('class' => 'filter_jwplayer_media'));
+            $output .= html_writer::tag('span', $outerspan, $newattributes);
         }
 
         return $output;


### PR DESCRIPTION
Allows user to set player css using the style attribute of the a tag.

This is passed to the filter_jwplayer_media tag.

If a user wanted the video right aligned they could just set style="text-align: right" in the a tag to override the default centering.
