### PR TITLE
filter_jwplayer:  default to flash player if hls or smil files included in urls

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -177,8 +177,14 @@ class filter_jwplayer_media extends core_media_player {
                 'file' => urldecode($url),
             );
             // Help to determine the type of mov.
-            if (strtolower(pathinfo($url, PATHINFO_EXTENSION)) === 'mov') {
+            $ext = strtolower(pathinfo($url, PATHINFO_EXTENSION));
+            if ($ext === 'mov') {
                 $source['type'] = 'mp4';
+            } else if ($ext === 'm3u8' || $ext === 'smil') {
+                // HLS and Dynamic RTMP support requires flash on some platforms
+                // Set rendering mode to flash to ensure streams play if possible
+                // even when mp4 fallbacks are given.
+                $playersetupdata['primary'] = 'flash';
             }
 
             if ($url->get_scheme() === 'rtmp') {


### PR DESCRIPTION
HLS and dynamic RTMP streams require the flash player on most platforms (http://support.jwplayer.com/customer/portal/articles/1403635-media-format-reference ).

If a fallback mp4 is included in the sources, then the default HTML5 player is used as it will play this causing the fallback to become the default.

Primary needs to be set to flash in these cases to prevent this (see http://support.jwplayer.com/customer/portal/articles/1430218-using-hls-streaming ).