### PR TITLE
filter_jwplayer:  Fix alignment for flash player

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -279,7 +279,8 @@ class filter_jwplayer_media extends core_media_player {
 
             $PAGE->requires->js_init_call('M.filter_jwplayer.init', $playersetup, true, $jsmodule);
             $playerdiv = html_writer::tag('span', $this->get_name('', $urls), array('id' => $playerid));
-            $output .= html_writer::tag('span', $playerdiv, array('class' => 'filter_jwplayer_media'));
+            $outerspan = html_writer::tag('span', $playerdiv, array('class' => 'filter_jwplayer_playerblock'));
+            $output .= html_writer::tag('span', $outerspan, array('class' => 'filter_jwplayer_media'));
         }
 
         return $output;

--- a/styles.css
+++ b/styles.css
@@ -2,4 +2,4 @@
  * Filter JWPlayer
  */
 .filter_jwplayer_media {display:block;margin-top:5px;margin-bottom:5px;text-align: center;}
-.filter_jwplayer_media .jwplayer{display:inline-block;}
+.filter_jwplayer_playerblock{display:inline-block;}


### PR DESCRIPTION
Previous fix in pull request #24 appears not to apply to the flash player just the HTML5 one.

This fix adds an additional span around the player, which is set to display: inline-block instead of the player's own tag to ensure centering happens regardless of the player type.