### PR TITLE
filter_jwplayer:  Add support for passing attributes to player via the a tag attributes

### DIFF
--- a/filter.php
+++ b/filter.php
@@ -95,15 +95,26 @@ class filter_jwplayer extends moodle_text_filter {
             return $matches[0];
         }
 
+        $options = array();
+		
         // Get name.
         $name = trim($matches[2]);
         if (empty($name) or strpos($name, 'http') === 0) {
             $name = ''; // Use default name.
         }
 
+        // Get <a> tag attributes.
+        $escapedmatch = preg_replace('/&(?!(?:apos|quot|[gl]t|amp);|#)/','&amp;',$matches[0]); // Escape any unescaped & characters.
+        $doc = new DOMDocument();
+        $doc->strictErrorChecking = FALSE;
+        $doc->loadHTML($escapedmatch);  // Load HTML as a DOMDocument.
+        if ($atag = simplexml_import_dom($doc)->body[0]->a[0]){  // Make sure xml is valid xml if not do nothing.
+            $options['htmlattributes'] = $atag->attributes();
+        }
+
         // Split provided URL into alternatives.
         $urls = filter_jwplayer_split_alternatives($matches[1], $width, $height);
-        $result = $this->renderer->embed_alternatives($urls, $name, $width, $height);
+        $result = $this->renderer->embed_alternatives($urls, $name, $width, $height, $options);
 
         // If something was embedded, return it, otherwise return original.
         if ($result !== '') {

--- a/lib.php
+++ b/lib.php
@@ -214,12 +214,55 @@ class filter_jwplayer_media extends core_media_player {
         if (count($sources) > 0) {
             $playerid = 'filter_jwplayer_media_' . html_writer::random_id();
 
-            $playersetupdata['title'] = $this->get_name('', $urls);
+            // Set Title from title attribute of a tag if it has one if not default to filename.
+            if (isset($options['htmlattributes']['title'])) {
+                $playersetupdata['title'] = $options['htmlattributes']['title'];
+            } else {
+                $playersetupdata['title'] = $this->get_name('', $urls);
+            }
+            
+            // Process data-jwplayer attributes.
+            foreach ($options['htmlattributes'] as $attrib => $atval) {
+                if (strpos($attrib, 'data-jwplayer-') === 0) {  // treat attributes starting data-jwplayer as options.
+                    $opt = preg_replace('~^data-jwplayer-~', '', $attrib);
+                    $atval = trim($atval);
+                    if (strpos($atval, ': ') || strpos($atval, '; ') || strpos($atval,', ')) {  // if attribute contains any of :;, it needs to be split to an array.
+                        $atvalarray = preg_split('~[,;] ~', $atval);
+                        $newatval = array();
+                        foreach ($atvalarray as $dataval) {
+                            $newdata = explode(': ', $dataval,2);
+                            if (count($newdata) > 1){
+                                $newdata[1] = trim($newdata[1]);
+                                if (filter_var($newdata[1], FILTER_VALIDATE_URL)) { // if value is a URL convert to moodle_url.
+                                    $newdata[1] = new moodle_url($newdata[1]);
+                                }
+                                $newatval[trim($newdata[0])] = $newdata[1];
+                            } else {
+                                $newdata[0] = trim($newdata[0]);
+                                if (filter_var($newdata[0], FILTER_VALIDATE_URL)) { // if value is a URL convert to moodle_url.
+                                    $newdata[0] = new moodle_url($newdata[0]);
+                                }
+                                $newatval[] = $newdata[0];
+                            }
+                        }
+                        $atval = $newatval;
+                    } else if (filter_var($atval, FILTER_VALIDATE_URL)) { // if value is a URL convert to moodle_url.
+                        $atval = new moodle_url($atval);
+                    }
+                    $options[$opt] = $atval;
+                } else {
+                    // Pass any other global HTML attributes to the player span tag.
+                    $globalhtmlattributes = array('accesskey', 'class', 'contenteditable', 'contextmenu', 'dir', 'draggable', 'dropzone', 'hidden', 'id', 'lang', 'spellcheck', 'style', 'tabindex', 'title', 'translate');
+                    if (in_array($attrib, $globalhtmlattributes) || strpos($attrib, 'data-' === 0)) {
+                        $newattributes[$attrib] = $atval;  
+                    }
+                }
+            }
 
             $playlistitem = array('sources' => $sources);
 
             // Setup poster image.
-            if (isset($options['image'])) {
+            if (isset($options['image']) && $options['image'] instanceof moodle_url) {
                 $playlistitem['image'] = urldecode($options['image']->out(false));
             } else if ($poster = get_config('filter_jwplayer', 'defaultposter')) {
                 $syscontext = context_system::instance();
@@ -230,10 +273,12 @@ class filter_jwplayer_media extends core_media_player {
             if (isset($options['subtitles'])) {
                 $tracks = array();
                 foreach ($options['subtitles'] as $label => $subtitlefileurl) {
-                    $tracks[] = array(
-                        'file' => urldecode($subtitlefileurl->out(false)),
-                        'label' => $label,
-                    );
+                    if ($subtitlefileurl instanceof moodle_url) {
+                        $tracks[] = array(
+                            'file' => urldecode($subtitlefileurl->out(false)),
+                            'label' => $label,
+                        );
+                    }
                 }
                 $playlistitem['tracks'] = $tracks;
             }
@@ -324,11 +369,18 @@ class filter_jwplayer_media extends core_media_player {
             );
 
             $this->setup();
+			
+            // Set required class for player span tag.
+            if (isset($options['htmlattributes']['class'])) {
+                $newattributes['class'] .= ' filter_jwplayer_media';
+            } else {
+                $newattributes['class'] = 'filter_jwplayer_media';
+            }
 
             $PAGE->requires->js_init_call('M.filter_jwplayer.init', $playersetup, true, $jsmodule);
             $playerdiv = html_writer::tag('span', $this->get_name('', $urls), array('id' => $playerid));
             $outerspan = html_writer::tag('span', $playerdiv, $outerspanargs);
-            $output .= html_writer::tag('span', $outerspan, array('class' => 'filter_jwplayer_media'));
+            $output .= html_writer::tag('span', $outerspan, $newattributes);
         }
 
         return $output;


### PR DESCRIPTION
title attribute can be used to set title
data-jwplayer- attributes can be used to set player options

e.g. use data-jwplayer-image for the image option

array options can be , or ; separated with name, value pairs separated by : (like css or json):

e.g. data-jwplayer-subtitles="English: http://path.to/english.vtt, German: http://path.to/german.vtt"

Any other valid global html attributes (see http://www.w3schools.com/tags/ref_standardattributes.asp for a list) will be passed through to the outermost of the created span tags allowing the user to set additional css classes, specify element ids, etc as necessary.

Also fixes a bug in the simplexml attributes lookup which was looking at wrong node <html> rather than <a>

Also adds checks on image and subtitle options to ensure objects are of the expected moodle_url objects
