### PR TITLE
filter_jwplayer:  Update to support JWPlayer 7

### DIFF
--- a/lang/en/filter_jwplayer.php
+++ b/lang/en/filter_jwplayer.php
@@ -25,8 +25,10 @@
 
 $string['accounttoken'] = 'Cloud-hosted player account token';
 $string['accounttokendesc'] = 'Cloud-hosted player account token from account settings page on <a href="https://account.jwplayer.com/#/account">JW player website</a>. This is the file name from cloud-hosted player code, e.g. for script path http://jwpsrv.com/library/ABCDEF012345.js the corresponding account token that needs to be entered in the field above is ABCDEF012345. Not required if self-hosted player is used.';
-$string['customskin'] = 'Custom skin file';
-$string['customskindesc'] = 'Use a custom skin.  This must be packaged in xml format as described on the <a href="http://support.jwplayer.com/customer/portal/articles/2051702-jw6-building-jw-player-skins">JWPlayer website</a>.';
+$string['customskin'] = 'Custom XML skin file (v6)';
+$string['customskindesc'] = 'Use a custom XML skin (JWPlayer version 6 only).  This must be packaged in xml format as described on the <a href="http://support.jwplayer.com/customer/portal/articles/2051708-jw6-skin-xml-reference">JWPlayer website</a>.';
+$string['customskincss'] = 'Custom CSS skin name (v7)';
+$string['customskincssdesc'] = 'Use a custom CSS skin (JWPlayer version 7).  Styles should be added to the site css as described in <a href="http://support.jwplayer.com/customer/portal/articles/1412123-building-jw-player-skins">JWPlayer website</a>.';
 $string['downloadbutton'] = 'Download button';
 $string['downloadbuttondesc'] = 'Add a button in the upper left corner of the player for downloading the video file.';
 $string['defaultposter'] = 'Default poster';

--- a/lib.php
+++ b/lib.php
@@ -197,6 +197,10 @@ class filter_jwplayer_media extends core_media_player {
             $ext = strtolower(pathinfo($url, PATHINFO_EXTENSION));
             if ($ext === 'mov') {
                 $source['type'] = 'mp4';
+            } else if ($ext === 'mpd') {
+                // Dash variable needs to be set if we have a dash stream_bucket_append
+                $playersetupdata['dash'] = true;
+                $isstream = true;
             }
 
             if ($url->get_scheme() === 'rtmp' || $ext === 'm3u8' || $ext === 'smil') {
@@ -290,7 +294,9 @@ class filter_jwplayer_media extends core_media_player {
             }
 
             // Load skin.
-            if ($customskin = get_config('filter_jwplayer', 'customskin')) {
+            if ($customskincss = get_config('filter_jwplayer', 'customskincss')) {
+                $playersetupdata['skin'] = $customskincss;
+            } else if ($customskin = get_config('filter_jwplayer', 'customskin')) {
                 $syscontext = context_system::instance();
                 $playersetupdata['skin'] = moodle_url::make_pluginfile_url($syscontext->id, 'filter_jwplayer', 'playerskin', null, null, $customskin)->out(true);
             } else if ($skin = get_config('filter_jwplayer', 'skin')) {
@@ -366,7 +372,7 @@ class filter_jwplayer_media extends core_media_player {
     public function list_supported_extensions() {
         $video = array('mp4', 'm4v', 'f4v', 'mov', 'flv', 'webm', 'ogv');
         $audio = array('aac', 'm4a', 'f4a', 'mp3', 'ogg', 'oga');
-        $streaming = array('m3u8', 'smil');
+        $streaming = array('m3u8', 'smil', 'mpd');
         return array_merge($video, $audio, $streaming);
     }
 

--- a/settings.php
+++ b/settings.php
@@ -61,6 +61,7 @@ if ($ADMIN->fulltree) {
     // Enabled extensions.
     $supportedextensions = $jwplayer->list_supported_extensions();
     $enabledextensionsmenu = array_combine($supportedextensions, $supportedextensions);
+    array_splice($supportedextensions, array_search('mpd', $supportedextensions), 1);  // disable mpeg-dash by default in case we are using JWPlayer 6
     $settings->add(new admin_setting_configmultiselect('filter_jwplayer/enabledextensions',
             get_string('enabledextensions', 'filter_jwplayer'),
             get_string('enabledextensionsdesc', 'filter_jwplayer'),
@@ -116,6 +117,11 @@ if ($ADMIN->fulltree) {
             'playerskin',
             0,
             array('accepted_types' => array('.xml'))));
+            
+    $settings->add(new admin_setting_configtext('filter_jwplayer/customskincss',
+            get_string('customskincss', 'filter_jwplayer'),
+            get_string('customskincssdesc', 'filter_jwplayer'),
+            ''));
 
     // Google Analytics support.
     $settings->add(new admin_setting_configcheckbox('filter_jwplayer/googleanalytics',


### PR DESCRIPTION
Adds CSS custom skin support (XML skins no longer supported by player)
Adds mpeg-dash (.mpd) to supported extensions (off by default)

Fixes bug recognising extensions when query string included.
i.e. http://example.com/file.ext?query was being recognised as a ext?query extension rather than ext
