### PR TITLE
filter_jwplayer:  Fix recognition of file extensions for urls with query strings (bug #35) (JW6)

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -194,7 +194,7 @@ class filter_jwplayer_media extends core_media_player {
                 'file' => urldecode($url->out(false)),
             );
             // Help to determine the type of mov.
-            $ext = strtolower(pathinfo($url, PATHINFO_EXTENSION));
+            $ext = core_media::get_extension($url);
             if ($ext === 'mov') {
                 $source['type'] = 'mp4';
             }


### PR DESCRIPTION
Fix for bug #35 from pull request #36 submitted for the JW6 branch as it effects both versions.
