### PR TITLE
filter_jwplayer:  Update google analytics options (issue #37)

### DIFF
--- a/lang/en/filter_jwplayer.php
+++ b/lang/en/filter_jwplayer.php
@@ -40,8 +40,10 @@ $string['enabledextensionsdesc'] = 'Only selected file extensions will be handle
 $string['errornoaccounttoken'] = 'Cloud-hosted player requires account token';
 $string['errornojwplayerinstalled'] = 'No JW player files found in Moodle';
 $string['filtername'] = 'JW Player multimedia filter';
-$string['gatrackingobject'] = 'Google Analytics Tracking Object';
-$string['gatrackingobjectdesc'] = 'If you have changed the name of tracking object variable used by Google Analytics, set this here.  In most cases the default _gaq should be correct.';
+$string['gaidstring'] = 'Play/Complete Action';
+$string['gaidstringdesc'] = 'Action to record in Google Analytics for Play/Complete Events (e.g. file or title).  See the of ga.idstring setting on <a href="http://support.jwplayer.com/customer/portal/articles/1417179-integration-with-google-analytics">JWPlayer</a> website for more details.';
+$string['galabel'] = 'Other Event Action';
+$string['galabeldesc'] = 'Label to record in Google Analytics for player Events (e.g. file or title).  See the of ga.label setting on <a href="http://support.jwplayer.com/customer/portal/articles/1417179-integration-with-google-analytics">JWPlayer</a> website for more details.';
 $string['googleanalytics'] = 'Google Analytics Integration';
 $string['googleanalyticsdesc'] = 'Enable integration with Google Analytics.  Requires Google Analytics code to already be added to pages.  See details on the <a href="http://support.jwplayer.com/customer/portal/articles/1417179-integration-with-google-analytics">JW player website</a> for more information.';
 $string['hostingmethod'] = 'Player hosting method';

--- a/lib.php
+++ b/lib.php
@@ -218,7 +218,7 @@ class filter_jwplayer_media extends core_media_player {
         if (count($sources) > 0) {
             $playerid = 'filter_jwplayer_media_' . html_writer::random_id();
 
-            
+
             // Process data-jwplayer attributes.
             foreach ($options['htmlattributes'] as $attrib => $atval) {
                 if (strpos($attrib, 'data-jwplayer-') === 0) {  // treat attributes starting data-jwplayer as options.
@@ -252,7 +252,7 @@ class filter_jwplayer_media extends core_media_player {
                     // Pass any other global HTML attributes to the player span tag.
                     $globalhtmlattributes = array('accesskey', 'class', 'contenteditable', 'contextmenu', 'dir', 'draggable', 'dropzone', 'hidden', 'id', 'lang', 'spellcheck', 'style', 'tabindex', 'title', 'translate');
                     if (in_array($attrib, $globalhtmlattributes) || strpos($attrib, 'data-' === 0)) {
-                        $newattributes[$attrib] = $atval;  
+                        $newattributes[$attrib] = $atval;
                     }
                 }
             }
@@ -353,9 +353,23 @@ class filter_jwplayer_media extends core_media_player {
                 );
             }
 
+            // Set Google Analytics settings if enabled.
             if (get_config('filter_jwplayer', 'googleanalytics')) {
+                if (isset($options['gaidstring'])) {
+                    $gaidstring = $options['gaidstring'];
+                } else {
+                    $gaidstring = get_config('filter_jwplayer', 'gaidstring');
+                }
+
+                if (isset($options['galabel'])) {
+                    $galabel = $options['galabel'];
+                } else {
+                    $galabel = get_config('filter_jwplayer', 'galabel');
+                }
+
                 $playersetupdata['ga'] = array(
-                    'trackingobject' => get_config('filter_jwplayer', 'gatrackingobject'),
+                    'idstring' => $gaidstring,
+                    'label' => $galabel
                 );
             }
 
@@ -372,7 +386,7 @@ class filter_jwplayer_media extends core_media_player {
             );
 
             $this->setup();
-			
+
             // Set required class for player span tag.
             if (isset($options['htmlattributes']['class'])) {
                 $newattributes['class'] .= ' filter_jwplayer_media';

--- a/settings.php
+++ b/settings.php
@@ -89,7 +89,7 @@ if ($ADMIN->fulltree) {
             get_string('downloadbutton', 'filter_jwplayer'),
             get_string('downloadbuttondesc', 'filter_jwplayer'),
             0));
-            
+
     // Display Style (Fixed Width or Responsive).
     $displaystylechoice = array(
         'fixed' => get_string('displayfixed', 'filter_jwplayer'),
@@ -118,9 +118,14 @@ if ($ADMIN->fulltree) {
             get_string('googleanalytics', 'filter_jwplayer'),
             get_string('googleanalyticsdesc', 'filter_jwplayer'),
             0));
-			
-    $settings->add(new admin_setting_configtext('filter_jwplayer/gatrackingobject',
-            get_string('gatrackingobject', 'filter_jwplayer'),
-            get_string('gatrackingobjectdesc', 'filter_jwplayer'),
-            '_gaq'));
+
+    $settings->add(new admin_setting_configtext('filter_jwplayer/gaidstring',
+            get_string('gaidstring', 'filter_jwplayer'),
+            get_string('gaidstringdesc', 'filter_jwplayer'),
+            'file'));
+
+    $settings->add(new admin_setting_configtext('filter_jwplayer/galabel',
+            get_string('galabel', 'filter_jwplayer'),
+            get_string('galabeldesc', 'filter_jwplayer'),
+            'file'));
 }


### PR DESCRIPTION
Remove ga.trackingobject setting no longer supported in JWPlayer 7
Add ga.idstring and ga.label settings to allow customisation of recorded events

Addresses google analytics issues from task #37 
